### PR TITLE
More permissive lower bound for resourcet

### DIFF
--- a/amazonka-s3-streaming.cabal
+++ b/amazonka-s3-streaming.cabal
@@ -42,7 +42,7 @@ library
                        , http-client-tls  >= 0.3        && < 0.4
                        , transformers     >= 0.5        && < 0.7
                        , text             >= 1.2.4      && < 1.3 || >= 2.0 && < 2.2
-                       , resourcet        >= 1.3.0      && < 1.4
+                       , resourcet        >= 1.2.0      && < 1.4
 
 flag s3upload-exe
   Description: Whether to build the s3upload executable for uploading files using this library.


### PR DESCRIPTION
1.3.0 lowerbound for resourcet unnecessarily excludes versions with which the package is working fine (e.g. amazonka even has `resourcet >=1.1`).

We're using stack  lts-20.26 (based on ghc-9.2.8) which has resourcet-1.2.6.
When I add resourcet-1.3.0 to extra-deps in stack.yaml, I get bunch of other version conflicts (e.g. servant-server-0.19.2 from stack lts permits `resourcet >=1.2.2 && <1.3`

Long story short, let's please lower resourcet bound before releasing.
